### PR TITLE
Support for data type in CSV class.

### DIFF
--- a/grasp.py
+++ b/grasp.py
@@ -434,12 +434,13 @@ class matrix(list):
 
 class CSV(matrix):
 
-    def __init__(self, name='', separator=',', rows=[]):
+    def __init__(self, name='', separator=',', rows=[], dtype = u):
         """ Returns the given .csv file as a list of rows, each a list of values.
         """
         try:
             self.name      = name
             self.separator = separator
+            self.dtype = dtype
             self._load()
         except IOError:
             pass # doesn't exist (yet)
@@ -449,7 +450,7 @@ class CSV(matrix):
     def _load(self):
         with open(self.name, 'r') as f:
             for r in csvlib.reader(f, delimiter=self.separator):
-                r = [u(v) for v in r]
+                r = [self.dtype(v) for v in r]
                 self.append(r)
 
     def save(self, name=''):


### PR DESCRIPTION
Currently, CSV class object doesn't care about the DataType of incoming/outgoing data. This can create inconvenience for some users. For eg. if I have a numerical CSV file, the CSV._load() function still loads all data in unicode string format.

This patch allows users to send Datatype also, when they are initiating a CSV object. In case no datatype is given, datatype defaults to unicode/u.