### PR TITLE
Support for number of columns in CSV class

### DIFF
--- a/grasp.py
+++ b/grasp.py
@@ -434,12 +434,15 @@ class matrix(list):
 
 class CSV(matrix):
 
-    def __init__(self, name='', separator=',', rows=[]):
+    def __init__(self, name='', separator=',', rows=[], n_cols=None):
         """ Returns the given .csv file as a list of rows, each a list of values.
         """
         try:
             self.name      = name
             self.separator = separator
+            # n_cols stores number of initial columns to be used in CSV matrix
+            # Default value is None, later is set to maximum number of cols.
+            self.n_cols = n_cols
             self._load()
         except IOError:
             pass # doesn't exist (yet)
@@ -449,8 +452,10 @@ class CSV(matrix):
     def _load(self):
         with open(self.name, 'r') as f:
             for r in csvlib.reader(f, delimiter=self.separator):
+                r = r[:self.n_cols] if self.n_cols else r
                 r = [u(v) for v in r]
                 self.append(r)
+            self.n_cols = len(self[0])
 
     def save(self, name=''):
         a = []


### PR DESCRIPTION
This patch allows user to give an additional argument describing number of columns to be read from stored CSV file.
for eg. 
test.csv contents
```
1,2,3,4
```

```python
>>> d = csv("test.csv", n_cols = 1)
>>> d
[[u'1']]
>>> d = csv("test.csv", n_cols = 3)
>>> d
[[u'1', u'2', u'3']]
>>> d = csv("test.csv")
>>> d
[[u'1', u'2', u'3', u'4']]

```